### PR TITLE
Add portal API and Next.js UI scaffold with DB schema and webhook ingestion

### DIFF
--- a/portal-api/.env.template
+++ b/portal-api/.env.template
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/voice_portal
+AUTH0_DOMAIN=example.eu.auth0.com
+AUTH0_AUDIENCE=https://portal.example.com
+AUTH0_ISSUER=https://example.eu.auth0.com/
+WEBHOOK_SECRET=replace_me

--- a/portal-api/app/auth.py
+++ b/portal-api/app/auth.py
@@ -1,0 +1,63 @@
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+
+import requests
+from jose import jwt
+from jose.exceptions import JWTError
+
+from .config import AUTH0_AUDIENCE, AUTH0_DOMAIN, AUTH0_ISSUER
+
+
+@dataclass
+class AuthContext:
+    user_id: str
+    email: str
+    token: str
+
+
+def _jwks_url() -> str:
+    if not AUTH0_DOMAIN:
+        raise RuntimeError("AUTH0_DOMAIN is not set.")
+    return f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+
+
+@lru_cache(maxsize=1)
+def _load_jwks() -> dict:
+    response = requests.get(_jwks_url(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_rsa_key(token: str) -> dict | None:
+    headers = jwt.get_unverified_header(token)
+    kid = headers.get("kid")
+    if not kid:
+        return None
+    jwks = _load_jwks()
+    for key in jwks.get("keys", []):
+        if key.get("kid") == kid:
+            return key
+    return None
+
+
+def verify_token(token: str) -> AuthContext:
+    if not AUTH0_AUDIENCE or not AUTH0_ISSUER:
+        raise RuntimeError("AUTH0_AUDIENCE or AUTH0_ISSUER is not set.")
+
+    rsa_key = _get_rsa_key(token)
+    if not rsa_key:
+        raise JWTError("Unable to find matching RSA key.")
+
+    payload = jwt.decode(
+        token,
+        rsa_key,
+        algorithms=["RS256"],
+        audience=AUTH0_AUDIENCE,
+        issuer=AUTH0_ISSUER,
+    )
+    email = payload.get("email") or payload.get("https://example.com/email")
+    if not email:
+        raise JWTError("Missing email in token.")
+    user_id = payload.get("sub", "")
+    return AuthContext(user_id=user_id, email=email, token=token)

--- a/portal-api/app/config.py
+++ b/portal-api/app/config.py
@@ -1,0 +1,21 @@
+import os
+
+
+def _get_env(name: str, default: str | None = None) -> str | None:
+    value = os.getenv(name, default)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or default
+
+
+DATABASE_URL = _get_env("DATABASE_URL")
+
+AUTH0_DOMAIN = _get_env("AUTH0_DOMAIN")
+AUTH0_AUDIENCE = _get_env("AUTH0_AUDIENCE")
+AUTH0_ISSUER = _get_env("AUTH0_ISSUER")
+
+WEBHOOK_SECRET = _get_env("WEBHOOK_SECRET")
+
+DEFAULT_TIMEZONE = _get_env("DEFAULT_TIMEZONE", "UTC")
+SLA_TARGET_DEFAULT_SEC = int(_get_env("SLA_TARGET_DEFAULT_SEC", "10"))

--- a/portal-api/app/db.py
+++ b/portal-api/app/db.py
@@ -1,0 +1,27 @@
+from contextlib import contextmanager
+
+import psycopg
+
+from .config import DATABASE_URL
+
+
+def _require_db_url() -> str:
+    if not DATABASE_URL:
+        raise RuntimeError("DATABASE_URL is not set.")
+    return DATABASE_URL
+
+
+@contextmanager
+def get_db():
+    conn = psycopg.connect(_require_db_url())
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def get_db_cursor():
+    with get_db() as conn:
+        with conn.cursor() as cursor:
+            yield conn, cursor

--- a/portal-api/app/main.py
+++ b/portal-api/app/main.py
@@ -1,0 +1,732 @@
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+from .auth import AuthContext, verify_token
+from .config import SLA_TARGET_DEFAULT_SEC, WEBHOOK_SECRET
+from .db import get_db_cursor
+from .schemas import Settings, UserContext, settings_to_dict
+
+load_dotenv()
+
+app = FastAPI(title="Voice Agent Portal API")
+
+
+def _require_auth_header(auth_header: str | None) -> str:
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing Authorization header.")
+    return auth_header.replace("Bearer ", "", 1).strip()
+
+
+def _get_auth_context(authorization: str = Header(default=None)) -> AuthContext:
+    token = _require_auth_header(authorization)
+    try:
+        return verify_token(token)
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+def _set_tenant_scope(cursor, tenant_id: str) -> None:
+    cursor.execute("select set_config('app.tenant_id', %s, true)", (tenant_id,))
+
+
+def _load_user_context(auth_ctx: AuthContext) -> UserContext:
+    with get_db_cursor() as (conn, cursor):
+        cursor.execute(
+            """
+            select u.id, u.email, u.full_name, t.id, t.name, utr.role
+            from users u
+            join user_tenant_roles utr on utr.user_id = u.id
+            join tenants t on t.id = utr.tenant_id
+            where u.email = %s
+            """,
+            (auth_ctx.email,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise HTTPException(status_code=403, detail="User not mapped to a tenant.")
+        user_id, email, full_name, tenant_id, tenant_name, role = row
+        return UserContext(
+            user={"id": str(user_id), "email": email, "fullName": full_name},
+            tenant={"id": str(tenant_id), "name": tenant_name},
+            role=role,
+        )
+
+
+def _get_settings(cursor, tenant_id: str) -> Settings:
+    cursor.execute(
+        """
+        select sla_target_sec, human_minutes_per_resolved_call, cost_per_minute,
+               currency, retention_days, mask_caller, recordings_enabled,
+               recordings_require_manager, updated_at
+        from tenant_settings
+        where tenant_id = %s
+        """,
+        (tenant_id,),
+    )
+    row = cursor.fetchone()
+    if row:
+        return Settings(*row)
+    return Settings(
+        sla_target_sec=SLA_TARGET_DEFAULT_SEC,
+        human_minutes_per_resolved_call=3.5,
+        cost_per_minute=0.5,
+        currency="EUR",
+        retention_days=90,
+        mask_caller=True,
+        recordings_enabled=True,
+        recordings_require_manager=True,
+        updated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+@app.get("/me")
+def get_me(auth_ctx: AuthContext = Depends(_get_auth_context)) -> dict[str, Any]:
+    return _load_user_context(auth_ctx).__dict__
+
+
+@app.get("/kpi/overview")
+def get_overview(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            with base as (
+                select *
+                from calls
+                where started_at >= %s and started_at < %s
+            )
+            select
+                count(*) as total_calls,
+                count(*) filter (where answered_at is not null) as answered_calls,
+                round(100.0 * count(*) filter (where answered_at is not null) / nullif(count(*),0), 2) as ai_answer_rate_pct,
+                count(*) filter (where outcome = 'resolved') as resolved_calls,
+                round(100.0 * count(*) filter (where outcome = 'resolved') / nullif(count(*),0), 2) as resolution_rate_pct,
+                count(*) filter (where outcome = 'escalated') as escalated_calls,
+                round(100.0 * count(*) filter (where outcome = 'escalated') / nullif(count(*),0), 2) as escalation_rate_pct,
+                count(*) filter (where outcome = 'failed') as failed_calls,
+                count(*) filter (where outcome = 'abandoned') as abandoned_calls,
+                round(avg(answer_time_sec)::numeric, 2) as avg_answer_time_sec,
+                percentile_cont(0.95) within group (order by answer_time_sec) as p95_answer_time_sec
+            from base
+            """,
+            (from_, to),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return {}
+        (
+            total_calls,
+            answered_calls,
+            ai_answer_rate_pct,
+            resolved_calls,
+            resolution_rate_pct,
+            escalated_calls,
+            escalation_rate_pct,
+            failed_calls,
+            abandoned_calls,
+            avg_answer_time_sec,
+            p95_answer_time_sec,
+        ) = row
+
+        cursor.execute(
+            """
+            with base as (
+                select answer_time_sec
+                from calls
+                where started_at >= %s and started_at < %s
+                  and answer_time_sec is not null
+            )
+            select
+                round(
+                    100.0 * count(*) filter (where answer_time_sec <= %s) / nullif(count(*),0),
+                    2
+                ) as sla_compliance_pct
+            from base
+            """,
+            (from_, to, settings.sla_target_sec),
+        )
+        sla_row = cursor.fetchone()
+        sla_compliance_pct = sla_row[0] if sla_row else None
+        return {
+            "totalCalls": total_calls,
+            "answeredCalls": answered_calls,
+            "aiAnswerRatePct": ai_answer_rate_pct,
+            "resolvedCalls": resolved_calls,
+            "resolutionRatePct": resolution_rate_pct,
+            "escalatedCalls": escalated_calls,
+            "escalationRatePct": escalation_rate_pct,
+            "failedCalls": failed_calls,
+            "abandonedCalls": abandoned_calls,
+            "avgAnswerTimeSec": avg_answer_time_sec,
+            "p95AnswerTimeSec": p95_answer_time_sec,
+            "slaTargetSec": settings.sla_target_sec,
+            "slaCompliancePct": sla_compliance_pct,
+        }
+
+
+@app.get("/kpi/overview/trend")
+def get_overview_trend(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select
+                date_trunc('day', started_at) as day,
+                count(*) as total,
+                count(*) filter (where outcome = 'resolved') as resolved,
+                count(*) filter (where outcome = 'escalated') as escalated,
+                count(*) filter (where outcome = 'failed') as failed,
+                count(*) filter (where outcome = 'abandoned') as abandoned
+            from calls
+            where started_at >= %s and started_at < %s
+            group by 1
+            order by 1 asc
+            """,
+            (from_, to),
+        )
+        points = [
+            {
+                "day": row[0].date().isoformat(),
+                "total": row[1],
+                "resolved": row[2],
+                "escalated": row[3],
+                "failed": row[4],
+                "abandoned": row[5],
+            }
+            for row in cursor.fetchall()
+        ]
+        return {"points": points}
+
+
+@app.get("/kpi/reasons")
+def get_reasons(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    limit: int = 10,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select
+                coalesce(reason, 'unknown') as reason,
+                count(*) as calls,
+                round(100.0 * count(*) filter (where outcome = 'resolved') / nullif(count(*),0), 2) as resolved_pct,
+                round(100.0 * count(*) filter (where outcome = 'escalated') / nullif(count(*),0), 2) as escalated_pct,
+                round(avg(duration_sec)::numeric, 2) as avg_duration_sec
+            from calls
+            where started_at >= %s and started_at < %s
+            group by 1
+            order by calls desc
+            limit %s
+            """,
+            (from_, to, limit),
+        )
+        items = [
+            {
+                "reason": row[0],
+                "calls": row[1],
+                "resolvedPct": row[2],
+                "escalatedPct": row[3],
+                "avgDurationSec": row[4],
+            }
+            for row in cursor.fetchall()
+        ]
+        return {"items": items}
+
+
+@app.get("/kpi/impact")
+def get_impact(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select count(*) filter (where outcome = 'resolved')
+            from calls
+            where started_at >= %s and started_at < %s
+            """,
+            (from_, to),
+        )
+        resolved_calls = cursor.fetchone()[0] or 0
+        human_minutes_saved = resolved_calls * settings.human_minutes_per_resolved_call
+        cost_saved = human_minutes_saved * settings.cost_per_minute
+        return {
+            "humanMinutesSaved": human_minutes_saved,
+            "estimatedCostSaved": cost_saved,
+            "assumptions": {
+                "humanMinutesPerResolvedCall": settings.human_minutes_per_resolved_call,
+                "costPerMinute": settings.cost_per_minute,
+                "currency": settings.currency,
+            },
+        }
+
+
+@app.get("/kpi/sla")
+def get_sla(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            with base as (
+                select answer_time_sec
+                from calls
+                where started_at >= %s and started_at < %s
+                  and answer_time_sec is not null
+            )
+            select
+                round(100.0 * count(*) filter (where answer_time_sec <= %s) / nullif(count(*),0), 2) as sla_compliance_pct,
+                round(100.0 * count(*) filter (where answer_time_sec <= 5) / nullif(count(*),0), 2) as within_5s_pct,
+                round(100.0 * count(*) filter (where answer_time_sec <= 10) / nullif(count(*),0), 2) as within_10s_pct,
+                round(100.0 * count(*) filter (where answer_time_sec <= 20) / nullif(count(*),0), 2) as within_20s_pct,
+                count(*) as sample_size
+            from base
+            """,
+            (from_, to, settings.sla_target_sec),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return {}
+        return {
+            "slaTargetSec": settings.sla_target_sec,
+            "slaCompliancePct": row[0],
+            "within5SecPct": row[1],
+            "within10SecPct": row[2],
+            "within20SecPct": row[3],
+            "sampleSizeAnswered": row[4],
+        }
+
+
+@app.get("/kpi/reliability")
+def get_reliability(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select
+                count(*) filter (where outcome = 'failed') as failed_calls,
+                count(*) filter (where error_code is not null) as errored_calls,
+                count(*) filter (where escalated = true) as escalations
+            from calls
+            where started_at >= %s and started_at < %s
+            """,
+            (from_, to),
+        )
+        row = cursor.fetchone()
+        return {
+            "failedCalls": row[0],
+            "erroredCalls": row[1],
+            "escalations": row[2],
+            "transferFailures": 0,
+        }
+
+
+@app.get("/calls")
+def get_calls(
+    from_: str = Query(..., alias="from"),
+    to: str,
+    outcome: str | None = None,
+    reason: str | None = None,
+    q: str | None = None,
+    page: int = 1,
+    pageSize: int = 20,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    offset = (page - 1) * pageSize
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select count(*)
+            from calls
+            where started_at >= %s and started_at < %s
+              and (%s is null or outcome = %s)
+              and (%s is null or reason = %s)
+              and (
+                    %s is null
+                    or vapi_call_id ilike '%%' || %s || '%%'
+                    or summary ilike '%%' || %s || '%%'
+              )
+            """,
+            (from_, to, outcome, outcome, reason, reason, q, q, q),
+        )
+        total = cursor.fetchone()[0]
+        cursor.execute(
+            """
+            select
+                vapi_call_id,
+                started_at,
+                duration_sec,
+                outcome,
+                reason,
+                summary,
+                case when caller_e164 is null then null else '***' || right(caller_e164, 4) end as caller_masked
+            from calls
+            where started_at >= %s and started_at < %s
+              and (%s is null or outcome = %s)
+              and (%s is null or reason = %s)
+              and (
+                    %s is null
+                    or vapi_call_id ilike '%%' || %s || '%%'
+                    or summary ilike '%%' || %s || '%%'
+              )
+            order by started_at desc
+            limit %s offset %s
+            """,
+            (from_, to, outcome, outcome, reason, reason, q, q, q, pageSize, offset),
+        )
+        items = [
+            {
+                "vapiCallId": row[0],
+                "startedAt": row[1].isoformat() if row[1] else None,
+                "durationSec": row[2],
+                "outcome": row[3],
+                "reason": row[4],
+                "summary": row[5],
+                "callerMasked": row[6],
+            }
+            for row in cursor.fetchall()
+        ]
+        return {"page": page, "pageSize": pageSize, "total": total, "items": items}
+
+
+@app.get("/calls/{vapi_call_id}")
+def get_call_detail(
+    vapi_call_id: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        cursor.execute(
+            """
+            select
+                vapi_call_id,
+                started_at,
+                answered_at,
+                ended_at,
+                duration_sec,
+                answer_time_sec,
+                direction,
+                caller_e164,
+                called_e164,
+                outcome,
+                escalated,
+                reason,
+                summary,
+                transcript_text,
+                recording_url,
+                structured_data,
+                ended_reason,
+                error_code
+            from calls
+            where vapi_call_id = %s
+            """,
+            (vapi_call_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Call not found.")
+        caller_masked = f"***{row[7][-4:]}" if row[7] else None
+        called_masked = f"***{row[8][-4:]}" if row[8] else None
+        return {
+            "vapiCallId": row[0],
+            "startedAt": row[1].isoformat() if row[1] else None,
+            "answeredAt": row[2].isoformat() if row[2] else None,
+            "endedAt": row[3].isoformat() if row[3] else None,
+            "durationSec": row[4],
+            "answerTimeSec": row[5],
+            "direction": row[6],
+            "callerMasked": caller_masked,
+            "calledMasked": called_masked,
+            "outcome": row[9],
+            "escalated": row[10],
+            "reason": row[11],
+            "summary": row[12],
+            "transcriptText": row[13],
+            "recording": {"available": row[14] is not None, "url": None},
+            "structuredData": row[15],
+            "technical": {"endedReason": row[16], "errorCode": row[17]},
+        }
+
+
+@app.get("/calls/{vapi_call_id}/recording")
+def get_recording(
+    vapi_call_id: str,
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        if not settings.recordings_enabled:
+            raise HTTPException(status_code=403, detail="Recordings disabled.")
+        if settings.recordings_require_manager and user_ctx.role == "viewer":
+            raise HTTPException(status_code=403, detail="Recording access denied.")
+        cursor.execute(
+            "select recording_url from calls where vapi_call_id = %s",
+            (vapi_call_id,),
+        )
+        row = cursor.fetchone()
+        if not row or not row[0]:
+            raise HTTPException(status_code=404, detail="Recording not available.")
+        return {"url": row[0], "expiresAt": None}
+
+
+@app.get("/settings")
+def get_settings(auth_ctx: AuthContext = Depends(_get_auth_context)) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        return settings_to_dict(settings)
+
+
+@app.patch("/settings")
+def update_settings(
+    payload: dict[str, Any],
+    auth_ctx: AuthContext = Depends(_get_auth_context),
+) -> dict[str, Any]:
+    user_ctx = _load_user_context(auth_ctx)
+    if user_ctx.role != "owner":
+        raise HTTPException(status_code=403, detail="Owner role required.")
+    fields = {
+        "sla_target_sec": payload.get("slaTargetSec"),
+        "human_minutes_per_resolved_call": payload.get("humanMinutesPerResolvedCall"),
+        "cost_per_minute": payload.get("costPerMinute"),
+        "currency": payload.get("currency"),
+        "retention_days": payload.get("retentionDays"),
+        "mask_caller": payload.get("maskCaller"),
+        "recordings_enabled": payload.get("recordingsEnabled"),
+        "recordings_require_manager": payload.get("recordingsRequireManager"),
+    }
+    updates = {k: v for k, v in fields.items() if v is not None}
+    if not updates:
+        raise HTTPException(status_code=400, detail="No settings to update.")
+    with get_db_cursor() as (conn, cursor):
+        _set_tenant_scope(cursor, user_ctx.tenant["id"])
+        columns = ", ".join(f"{key} = %s" for key in updates.keys())
+        cursor.execute(
+            f"""
+            insert into tenant_settings (tenant_id, {", ".join(updates.keys())})
+            values (%s, {", ".join(["%s"] * len(updates))})
+            on conflict (tenant_id)
+            do update set {columns}, updated_at = now()
+            """,
+            [user_ctx.tenant["id"], *updates.values()],
+        )
+        conn.commit()
+        settings = _get_settings(cursor, user_ctx.tenant["id"])
+        return settings_to_dict(settings)
+
+
+def _verify_signature(raw_body: bytes, signature: str, timestamp: str | None) -> bool:
+    if not WEBHOOK_SECRET:
+        return False
+    signed_payload = raw_body
+    if timestamp:
+        signed_payload = f"{timestamp}.".encode() + raw_body
+    expected = hmac.new(WEBHOOK_SECRET.encode(), signed_payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+
+def _parse_timestamp(header_value: str | None) -> int | None:
+    if not header_value:
+        return None
+    try:
+        return int(header_value)
+    except ValueError:
+        return None
+
+
+@app.post("/webhooks/vapi")
+async def vapi_webhook(
+    request: Request,
+    x_vapi_signature: str | None = Header(default=None),
+    x_vapi_timestamp: str | None = Header(default=None),
+    x_signature: str | None = Header(default=None),
+    x_timestamp: str | None = Header(default=None),
+) -> JSONResponse:
+    raw_body = await request.body()
+    signature = x_vapi_signature or x_signature
+    timestamp = x_vapi_timestamp or x_timestamp
+    if not signature:
+        raise HTTPException(status_code=401, detail="Missing signature.")
+    if timestamp:
+        ts = _parse_timestamp(timestamp)
+        if ts:
+            now = int(datetime.now(timezone.utc).timestamp())
+            if abs(now - ts) > 300:
+                raise HTTPException(status_code=401, detail="Stale webhook timestamp.")
+    if not _verify_signature(raw_body, signature, timestamp):
+        raise HTTPException(status_code=401, detail="Invalid signature.")
+
+    payload = json.loads(raw_body.decode())
+    message = payload.get("message", {})
+    event_type = message.get("type", "unknown")
+    call = message.get("call", {}) or {}
+    phone_number = message.get("phoneNumber", {}) or {}
+    call_id = call.get("id") or call.get("callId")
+
+    phone_number_id = phone_number.get("id") or call.get("phoneNumberId")
+    assistant_id = call.get("assistantId")
+    org_id = call.get("orgId")
+
+    with get_db_cursor() as (conn, cursor):
+        cursor.execute(
+            """
+            select tenant_id
+            from tenant_vapi_map
+            where vapi_phone_number_id = %s
+               or vapi_assistant_id = %s
+               or vapi_org_id = %s
+            limit 1
+            """,
+            (phone_number_id, assistant_id, org_id),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Tenant mapping not found.")
+        tenant_id = row[0]
+
+        payload_hash = hashlib.sha256(raw_body).hexdigest()
+        try:
+            cursor.execute(
+                """
+                insert into call_events_raw (tenant_id, vapi_call_id, event_type, payload, payload_hash)
+                values (%s, %s, %s, %s, %s)
+                """,
+                (tenant_id, call_id, event_type, json.dumps(payload), payload_hash),
+            )
+        except Exception:
+            conn.rollback()
+            return JSONResponse(content={"status": "duplicate"}, status_code=200)
+
+        started_at = call.get("startedAt")
+        ended_at = call.get("endedAt")
+        answered_at = call.get("answeredAt")
+        duration_sec = call.get("duration") or call.get("durationSec")
+        direction = call.get("direction") or "inbound"
+        caller = call.get("customer", {}).get("number") or call.get("from")
+        called = call.get("to")
+        outcome = call.get("outcome")
+        escalated = call.get("escalated") or False
+        ended_reason = call.get("endedReason")
+        summary = call.get("summary")
+        transcript_text = call.get("transcript")
+        recording_url = call.get("recordingUrl")
+        structured_data = call.get("analysis")
+        error_code = call.get("error")
+
+        cursor.execute(
+            """
+            insert into calls (
+                tenant_id, vapi_call_id, vapi_org_id, vapi_phone_number_id, vapi_assistant_id,
+                direction, caller_e164, called_e164,
+                started_at, answered_at, ended_at, duration_sec,
+                outcome, escalated, ended_reason, reason,
+                recording_url, transcript_text, summary,
+                structured_data, error_code
+            )
+            values (
+                %s, %s, %s, %s, %s,
+                %s, %s, %s,
+                %s, %s, %s, %s,
+                %s, %s, %s, %s,
+                %s, %s, %s,
+                %s, %s
+            )
+            on conflict (vapi_call_id) do update set
+                vapi_org_id = coalesce(excluded.vapi_org_id, calls.vapi_org_id),
+                vapi_phone_number_id = coalesce(excluded.vapi_phone_number_id, calls.vapi_phone_number_id),
+                vapi_assistant_id = coalesce(excluded.vapi_assistant_id, calls.vapi_assistant_id),
+                started_at = coalesce(calls.started_at, excluded.started_at),
+                answered_at = coalesce(calls.answered_at, excluded.answered_at),
+                ended_at = coalesce(excluded.ended_at, calls.ended_at),
+                duration_sec = coalesce(excluded.duration_sec, calls.duration_sec),
+                recording_url = coalesce(excluded.recording_url, calls.recording_url),
+                transcript_text = coalesce(excluded.transcript_text, calls.transcript_text),
+                summary = coalesce(excluded.summary, calls.summary),
+                structured_data = coalesce(excluded.structured_data, calls.structured_data),
+                escalated = calls.escalated or excluded.escalated,
+                outcome = coalesce(excluded.outcome, calls.outcome),
+                ended_reason = coalesce(excluded.ended_reason, calls.ended_reason),
+                error_code = coalesce(excluded.error_code, calls.error_code),
+                updated_at = now()
+            """,
+            (
+                tenant_id,
+                call_id,
+                org_id,
+                phone_number_id,
+                assistant_id,
+                direction,
+                caller,
+                called,
+                started_at,
+                answered_at,
+                ended_at,
+                duration_sec,
+                outcome,
+                escalated,
+                ended_reason,
+                call.get("reason"),
+                recording_url,
+                transcript_text,
+                summary,
+                json.dumps(structured_data) if structured_data else None,
+                error_code,
+            ),
+        )
+        cursor.execute(
+            """
+            update calls
+            set answer_time_sec = case
+                when started_at is not null and answered_at is not null
+                then extract(epoch from (answered_at - started_at))::int
+                else answer_time_sec
+            end
+            where vapi_call_id = %s
+            """,
+            (call_id,),
+        )
+        conn.commit()
+
+    return JSONResponse(content={"status": "ok"})

--- a/portal-api/app/schemas.py
+++ b/portal-api/app/schemas.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class UserInfo:
+    id: str
+    email: str
+    full_name: str | None
+
+
+@dataclass
+class TenantInfo:
+    id: str
+    name: str
+
+
+@dataclass
+class UserContext:
+    user: UserInfo
+    tenant: TenantInfo
+    role: str
+
+
+@dataclass
+class Settings:
+    sla_target_sec: int
+    human_minutes_per_resolved_call: float
+    cost_per_minute: float
+    currency: str
+    retention_days: int
+    mask_caller: bool
+    recordings_enabled: bool
+    recordings_require_manager: bool
+    updated_at: str | datetime
+
+
+def settings_to_dict(settings: Settings) -> dict[str, Any]:
+    updated_at = (
+        settings.updated_at.isoformat()
+        if isinstance(settings.updated_at, datetime)
+        else settings.updated_at
+    )
+    return {
+        "slaTargetSec": settings.sla_target_sec,
+        "humanMinutesPerResolvedCall": settings.human_minutes_per_resolved_call,
+        "costPerMinute": settings.cost_per_minute,
+        "currency": settings.currency,
+        "retentionDays": settings.retention_days,
+        "maskCaller": settings.mask_caller,
+        "recordingsEnabled": settings.recordings_enabled,
+        "recordingsRequireManager": settings.recordings_require_manager,
+        "updatedAt": updated_at,
+    }

--- a/portal-api/requirements.txt
+++ b/portal-api/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+psycopg==3.2.1
+python-dotenv==1.0.1
+python-jose==3.3.0
+requests==2.32.3

--- a/portal-api/sql/schema.sql
+++ b/portal-api/sql/schema.sql
@@ -1,0 +1,128 @@
+create extension if not exists "pgcrypto";
+create extension if not exists "citext";
+
+create table tenants (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  status text not null default 'active',
+  created_at timestamptz not null default now()
+);
+
+create table tenant_vapi_map (
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vapi_org_id text,
+  vapi_phone_number_id text,
+  vapi_assistant_id text,
+  created_at timestamptz not null default now(),
+  unique (tenant_id, vapi_phone_number_id),
+  unique (tenant_id, vapi_assistant_id)
+);
+
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  email citext unique not null,
+  full_name text,
+  created_at timestamptz not null default now()
+);
+
+create table user_tenant_roles (
+  user_id uuid not null references users(id) on delete cascade,
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  role text not null,
+  created_at timestamptz not null default now(),
+  primary key (user_id, tenant_id)
+);
+
+create table calls (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vapi_call_id text not null unique,
+  vapi_org_id text,
+  vapi_phone_number_id text,
+  vapi_assistant_id text,
+  direction text not null default 'inbound',
+  caller_e164 text,
+  called_e164 text,
+  started_at timestamptz,
+  answered_at timestamptz,
+  ended_at timestamptz,
+  duration_sec integer,
+  answer_time_sec integer,
+  outcome text,
+  ended_reason text,
+  escalated boolean not null default false,
+  reason text,
+  recording_url text,
+  transcript_text text,
+  summary text,
+  structured_data jsonb,
+  success_eval jsonb,
+  error_code text,
+  error_detail text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_calls_tenant_time on calls (tenant_id, started_at desc);
+create index idx_calls_tenant_outcome on calls (tenant_id, outcome);
+create index idx_calls_tenant_reason on calls (tenant_id, reason);
+
+create table call_variables (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vapi_call_id text not null references calls(vapi_call_id) on delete cascade,
+  key text not null,
+  value_text text,
+  value_number numeric,
+  value_json jsonb,
+  created_at timestamptz not null default now(),
+  unique (vapi_call_id, key)
+);
+
+create index idx_call_variables_tenant_key on call_variables (tenant_id, key);
+
+create table call_events_raw (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vapi_call_id text,
+  event_type text not null,
+  received_at timestamptz not null default now(),
+  payload jsonb not null,
+  payload_hash text
+);
+
+create index idx_call_events_call on call_events_raw (vapi_call_id, received_at desc);
+create index idx_call_events_tenant_time on call_events_raw (tenant_id, received_at desc);
+create unique index uniq_event_payload_per_tenant on call_events_raw(tenant_id, payload_hash);
+
+create table tenant_settings (
+  tenant_id uuid primary key references tenants(id) on delete cascade,
+  sla_target_sec integer not null default 10,
+  human_minutes_per_resolved_call numeric not null default 3.5,
+  cost_per_minute numeric not null default 0.5,
+  currency text not null default 'EUR',
+  retention_days integer not null default 90,
+  mask_caller boolean not null default true,
+  recordings_enabled boolean not null default true,
+  recordings_require_manager boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+alter table calls enable row level security;
+alter table call_events_raw enable row level security;
+alter table call_variables enable row level security;
+
+create policy tenant_isolation_calls
+on calls
+for select
+using (tenant_id = current_setting('app.tenant_id')::uuid);
+
+create policy tenant_isolation_events
+on call_events_raw
+for select
+using (tenant_id = current_setting('app.tenant_id')::uuid);
+
+create policy tenant_isolation_vars
+on call_variables
+for select
+using (tenant_id = current_setting('app.tenant_id')::uuid);

--- a/portal-ui/.env.template
+++ b/portal-ui/.env.template
@@ -1,0 +1,6 @@
+AUTH0_SECRET=replace_me
+AUTH0_BASE_URL=http://localhost:3000
+AUTH0_ISSUER_BASE_URL=https://example.eu.auth0.com
+AUTH0_CLIENT_ID=replace_me
+AUTH0_CLIENT_SECRET=replace_me
+PORTAL_API_BASE=http://localhost:8001

--- a/portal-ui/app/api/auth/[auth0]/route.ts
+++ b/portal-ui/app/api/auth/[auth0]/route.ts
@@ -1,0 +1,3 @@
+import { handleAuth } from "@auth0/nextjs-auth0";
+
+export const GET = handleAuth();

--- a/portal-ui/app/api/recordings/[vapiCallId]/route.ts
+++ b/portal-ui/app/api/recordings/[vapiCallId]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { apiFetch } from "@/lib/api";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { vapiCallId: string } }
+) {
+  const data = await apiFetch<{ url: string | null }>(`/calls/${params.vapiCallId}/recording`);
+  if (!data.url) {
+    return NextResponse.json({ error: "Recording unavailable" }, { status: 404 });
+  }
+  return NextResponse.redirect(data.url);
+}

--- a/portal-ui/app/calls/[vapiCallId]/page.tsx
+++ b/portal-ui/app/calls/[vapiCallId]/page.tsx
@@ -1,0 +1,73 @@
+import { apiFetch } from "@/lib/api";
+
+type CallDetail = {
+  vapiCallId: string;
+  startedAt: string;
+  answeredAt: string;
+  endedAt: string;
+  durationSec: number;
+  answerTimeSec: number;
+  direction: string;
+  callerMasked: string;
+  calledMasked: string;
+  outcome: string;
+  escalated: boolean;
+  reason: string;
+  summary: string;
+  transcriptText: string;
+  recording: { available: boolean; url: string | null };
+  structuredData: Record<string, unknown>;
+  technical: { endedReason: string; errorCode: string | null };
+};
+
+export default async function CallDetailPage({
+  params,
+}: {
+  params: { vapiCallId: string };
+}) {
+  const call = await apiFetch<CallDetail>(`/calls/${params.vapiCallId}`);
+
+  return (
+    <div>
+      <h1>Call {call.vapiCallId}</h1>
+      <div className="card">
+        <p>
+          <strong>Outcome:</strong> {call.outcome}
+        </p>
+        <p>
+          <strong>Reason:</strong> {call.reason}
+        </p>
+        <p>
+          <strong>Started:</strong> {call.startedAt}
+        </p>
+        <p>
+          <strong>Duration:</strong> {call.durationSec}s
+        </p>
+      </div>
+
+      <div className="card" style={{ marginTop: 16 }}>
+        <h3>Summary</h3>
+        <p>{call.summary}</p>
+      </div>
+
+      <div className="card" style={{ marginTop: 16 }}>
+        <h3>Transcript</h3>
+        <pre style={{ whiteSpace: "pre-wrap" }}>{call.transcriptText}</pre>
+      </div>
+
+      <div className="card" style={{ marginTop: 16 }}>
+        <h3>Recording</h3>
+        {call.recording.available ? (
+          <a href={`/api/recordings/${call.vapiCallId}`}>Open recording</a>
+        ) : (
+          <p>No recording available.</p>
+        )}
+      </div>
+
+      <div className="card" style={{ marginTop: 16 }}>
+        <h3>Structured Data</h3>
+        <pre>{JSON.stringify(call.structuredData, null, 2)}</pre>
+      </div>
+    </div>
+  );
+}

--- a/portal-ui/app/calls/page.tsx
+++ b/portal-ui/app/calls/page.tsx
@@ -1,0 +1,64 @@
+import { apiFetch } from "@/lib/api";
+
+type CallsResponse = {
+  page: number;
+  pageSize: number;
+  total: number;
+  items: {
+    vapiCallId: string;
+    startedAt: string;
+    durationSec: number;
+    outcome: string;
+    reason: string;
+    summary: string;
+    callerMasked: string;
+  }[];
+};
+
+function buildRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 7);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export default async function CallsPage() {
+  const { from, to } = buildRange();
+  const calls = await apiFetch<CallsResponse>(`/calls?from=${from}&to=${to}&page=1&pageSize=20`);
+
+  return (
+    <div>
+      <h1>Calls</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Caller</th>
+            <th>Duration</th>
+            <th>Outcome</th>
+            <th>Reason</th>
+            <th>Summary</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {calls.items.map((call) => (
+            <tr key={call.vapiCallId}>
+              <td>{call.startedAt}</td>
+              <td>{call.callerMasked}</td>
+              <td>{call.durationSec}s</td>
+              <td>
+                <span className={`badge ${call.outcome}`}>{call.outcome}</span>
+              </td>
+              <td>{call.reason}</td>
+              <td>{call.summary}</td>
+              <td>
+                <a href={`/calls/${call.vapiCallId}`}>Open</a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/portal-ui/app/globals.css
+++ b/portal-ui/app/globals.css
@@ -1,0 +1,90 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f7f7f8;
+  color: #111;
+}
+
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background: #1d1f25;
+  color: #fff;
+  padding: 24px;
+}
+
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.sidebar a {
+  color: #cbd5f5;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.content {
+  flex: 1;
+  padding: 32px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.badge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.badge.resolved {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge.escalated {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge.failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.badge.abandoned {
+  background: #e2e8f0;
+  color: #334155;
+}

--- a/portal-ui/app/layout.tsx
+++ b/portal-ui/app/layout.tsx
@@ -1,0 +1,30 @@
+import "./globals.css";
+import { UserProvider } from "@auth0/nextjs-auth0/client";
+
+export const metadata = {
+  title: "Voice Agent Portal",
+  description: "Ops dashboard for Vapi-powered voice agents.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <UserProvider>
+          <div className="layout">
+            <aside className="sidebar">
+              <h2>Voice Portal</h2>
+              <nav>
+                <a href="/overview">Overview</a>
+                <a href="/outcomes">Outcomes</a>
+                <a href="/sla">SLA & Reliability</a>
+                <a href="/calls">Calls</a>
+              </nav>
+            </aside>
+            <main className="content">{children}</main>
+          </div>
+        </UserProvider>
+      </body>
+    </html>
+  );
+}

--- a/portal-ui/app/outcomes/page.tsx
+++ b/portal-ui/app/outcomes/page.tsx
@@ -1,0 +1,74 @@
+import { apiFetch } from "@/lib/api";
+
+type Reasons = {
+  items: {
+    reason: string;
+    calls: number;
+    resolvedPct: number;
+    escalatedPct: number;
+    avgDurationSec: number;
+  }[];
+};
+
+type Impact = {
+  humanMinutesSaved: number;
+  estimatedCostSaved: number;
+  assumptions: {
+    humanMinutesPerResolvedCall: number;
+    costPerMinute: number;
+    currency: string;
+  };
+};
+
+function buildRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 7);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export default async function OutcomesPage() {
+  const { from, to } = buildRange();
+  const reasons = await apiFetch<Reasons>(`/kpi/reasons?from=${from}&to=${to}&limit=10`);
+  const impact = await apiFetch<Impact>(`/kpi/impact?from=${from}&to=${to}`);
+
+  return (
+    <div>
+      <h1>Outcomes & Reasons</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Reason</th>
+            <th>Calls</th>
+            <th>Resolved %</th>
+            <th>Escalated %</th>
+            <th>Avg Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          {reasons.items.map((item) => (
+            <tr key={item.reason}>
+              <td>{item.reason}</td>
+              <td>{item.calls}</td>
+              <td>{item.resolvedPct}%</td>
+              <td>{item.escalatedPct}%</td>
+              <td>{item.avgDurationSec}s</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="card" style={{ marginTop: 24 }}>
+        <h3>Automation Impact</h3>
+        <p>Human minutes saved: {impact.humanMinutesSaved}</p>
+        <p>
+          Estimated cost saved: {impact.estimatedCostSaved} {impact.assumptions.currency}
+        </p>
+        <small>
+          Assumptions: {impact.assumptions.humanMinutesPerResolvedCall} min/call @{" "}
+          {impact.assumptions.costPerMinute} {impact.assumptions.currency}/min
+        </small>
+      </div>
+    </div>
+  );
+}

--- a/portal-ui/app/overview/page.tsx
+++ b/portal-ui/app/overview/page.tsx
@@ -1,0 +1,81 @@
+import { apiFetch } from "@/lib/api";
+
+type Overview = {
+  totalCalls: number;
+  aiAnswerRatePct: number;
+  resolutionRatePct: number;
+  escalationRatePct: number;
+  failedCalls: number;
+  avgAnswerTimeSec: number;
+  p95AnswerTimeSec: number;
+  slaCompliancePct: number;
+};
+
+type Trend = {
+  points: { day: string; total: number; resolved: number; escalated: number; failed: number; abandoned: number }[];
+};
+
+function buildRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 7);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export default async function OverviewPage() {
+  const { from, to } = buildRange();
+  const overview = await apiFetch<Overview>(`/kpi/overview?from=${from}&to=${to}`);
+  const trend = await apiFetch<Trend>(`/kpi/overview/trend?from=${from}&to=${to}`);
+
+  return (
+    <div>
+      <h1>Overview</h1>
+      <div className="card-grid">
+        <div className="card">
+          <div>Total Calls</div>
+          <strong>{overview.totalCalls}</strong>
+        </div>
+        <div className="card">
+          <div>AI Answer Rate</div>
+          <strong>{overview.aiAnswerRatePct}%</strong>
+        </div>
+        <div className="card">
+          <div>Resolution Rate</div>
+          <strong>{overview.resolutionRatePct}%</strong>
+        </div>
+        <div className="card">
+          <div>Escalation Rate</div>
+          <strong>{overview.escalationRatePct}%</strong>
+        </div>
+        <div className="card">
+          <div>Failed Calls</div>
+          <strong>{overview.failedCalls}</strong>
+        </div>
+        <div className="card">
+          <div>Avg Answer Time</div>
+          <strong>{overview.avgAnswerTimeSec}s</strong>
+        </div>
+        <div className="card">
+          <div>P95 Answer Time</div>
+          <strong>{overview.p95AnswerTimeSec}s</strong>
+        </div>
+        <div className="card">
+          <div>SLA Compliance</div>
+          <strong>{overview.slaCompliancePct}%</strong>
+        </div>
+      </div>
+
+      <div className="card" style={{ marginTop: 24 }}>
+        <h3>Calls per day (last 7 days)</h3>
+        <ul>
+          {trend.points.map((point) => (
+            <li key={point.day}>
+              {point.day}: {point.total} total ({point.resolved} resolved, {point.escalated} escalated,{" "}
+              {point.failed} failed)
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/portal-ui/app/page.tsx
+++ b/portal-ui/app/page.tsx
@@ -1,0 +1,14 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Voice Agent Portal</h1>
+      <p>
+        Go to <a href="/overview">Overview</a> to view KPIs.
+      </p>
+      <p>
+        <a href="/api/auth/login">Log in</a> or{" "}
+        <a href="/api/auth/logout">log out</a>.
+      </p>
+    </div>
+  );
+}

--- a/portal-ui/app/sla/page.tsx
+++ b/portal-ui/app/sla/page.tsx
@@ -1,0 +1,62 @@
+import { apiFetch } from "@/lib/api";
+
+type Sla = {
+  slaTargetSec: number;
+  slaCompliancePct: number;
+  within5SecPct: number;
+  within10SecPct: number;
+  within20SecPct: number;
+  sampleSizeAnswered: number;
+};
+
+type Reliability = {
+  failedCalls: number;
+  erroredCalls: number;
+  escalations: number;
+  transferFailures: number;
+};
+
+function buildRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 7);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export default async function SlaPage() {
+  const { from, to } = buildRange();
+  const sla = await apiFetch<Sla>(`/kpi/sla?from=${from}&to=${to}`);
+  const reliability = await apiFetch<Reliability>(`/kpi/reliability?from=${from}&to=${to}`);
+
+  return (
+    <div>
+      <h1>SLA & Reliability</h1>
+      <div className="card-grid">
+        <div className="card">
+          <div>SLA Compliance</div>
+          <strong>{sla.slaCompliancePct}%</strong>
+        </div>
+        <div className="card">
+          <div>Within 5s</div>
+          <strong>{sla.within5SecPct}%</strong>
+        </div>
+        <div className="card">
+          <div>Within 10s</div>
+          <strong>{sla.within10SecPct}%</strong>
+        </div>
+        <div className="card">
+          <div>Within 20s</div>
+          <strong>{sla.within20SecPct}%</strong>
+        </div>
+      </div>
+
+      <div className="card" style={{ marginTop: 24 }}>
+        <h3>Reliability</h3>
+        <p>Failed calls: {reliability.failedCalls}</p>
+        <p>Errored calls: {reliability.erroredCalls}</p>
+        <p>Escalations: {reliability.escalations}</p>
+        <p>Transfer failures: {reliability.transferFailures}</p>
+      </div>
+    </div>
+  );
+}

--- a/portal-ui/lib/api.ts
+++ b/portal-ui/lib/api.ts
@@ -1,0 +1,17 @@
+import { getAccessToken } from "@auth0/nextjs-auth0";
+
+const API_BASE = process.env.PORTAL_API_BASE ?? "http://localhost:8001";
+
+export async function apiFetch<T>(path: string): Promise<T> {
+  const { accessToken } = await getAccessToken();
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}

--- a/portal-ui/next-env.d.ts
+++ b/portal-ui/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/portal-ui/next.config.js
+++ b/portal-ui/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/portal-ui/package.json
+++ b/portal-ui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "voice-portal-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@auth0/nextjs-auth0": "3.5.0",
+    "next": "14.2.7",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.8",
+    "@types/react": "18.3.4",
+    "typescript": "5.5.4"
+  }
+}

--- a/portal-ui/tsconfig.json
+++ b/portal-ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation

- Provide an operations dashboard and backend to surface KPIs and call data for Vapi-powered voice agents.
- Centralize tenant isolation and per-tenant settings so multiple orgs can be supported securely.
- Enable secure ingestion of Vapi webhook events with signature verification and deduplication.
- Offer a simple authenticated UI for owners and viewers via Auth0 to visualize metrics and access recordings.

### Description

- Add a FastAPI service under `portal-api/` with Auth0 token verification (`app/auth.py`), DB helpers (`app/db.py`), and the API surface in `app/main.py` implementing KPI endpoints, settings CRUD, calls endpoints, and the `/webhooks/vapi` ingestion path with HMAC signature checks and payload hashing for replay protection.
- Add Postgres schema `portal-api/sql/schema.sql` defining `tenants`, `calls`, `call_events_raw`, `tenant_settings`, RLS policies using `app.tenant_id`, and a unique index on `payload_hash` to prevent duplicate webhook processing.
- Add a Next.js UI scaffold under `portal-ui/` with Auth0 integration, pages for `overview`, `outcomes`, `sla`, `calls`, call detail pages, an API helper `lib/api.ts` that attaches the access token, and a recording redirect route at `app/api/recordings/[vapiCallId]/route.ts`.
- Include environment templates (`.env.template`) and `portal-api/requirements.txt` to document runtime dependencies and configuration variables.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69547cc84a188329a8a53ff66f5cc46d)